### PR TITLE
Rename plugin to embedded-glassfish-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </parent>
 
     <groupId>org.glassfish.embedded</groupId>
-    <artifactId>maven-embedded-glassfish-plugin</artifactId>
+    <artifactId>embedded-glassfish-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
     <version>5.1-SNAPSHOT</version>
 


### PR DESCRIPTION
As a plugin name of maven-* is reserved for official Apache plugins (https://maven.apache.org/guides/plugin/guide-java-plugin-development.html) it would be good to rename this plugin.