### PR TITLE
Bump version to 7.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <groupId>org.glassfish.embedded</groupId>
     <artifactId>maven-embedded-glassfish-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>5.1-SNAPSHOT</version>
+    <version>7.0-SNAPSHOT</version>
 
     <name>Maven Embedded GlassFish Plugin</name>
     <description>Maven Embedded GlassFish Plugin</description>

--- a/src/test/deploy/pom.xml
+++ b/src/test/deploy/pom.xml
@@ -2,6 +2,7 @@
 <!--
 
     Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2022 Contributors to Eclipse Foundation. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,7 +23,7 @@
   <parent>
     <groupId>org.glassfish.embedded.tester</groupId>
     <artifactId>tester-parent</artifactId>
-    <version>5.1-SNAPSHOT</version>
+    <version>7.0-SNAPSHOT</version>
   </parent>
   <artifactId>deploy-tester</artifactId>
   <packaging>pom</packaging>

--- a/src/test/pom.xml
+++ b/src/test/pom.xml
@@ -2,6 +2,7 @@
 <!--
 
     Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2022 Contributors to Eclipse Foundation. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -27,7 +28,7 @@
   <groupId>org.glassfish.embedded.tester</groupId>
   <artifactId>tester-parent</artifactId>
   <packaging>pom</packaging>
-  <version>5.1-SNAPSHOT</version>
+  <version>7.0-SNAPSHOT</version>
 
   <name>Glassfish Embedded Maven Plugin Tester Parent Pom</name>
 

--- a/src/test/start/pom.xml
+++ b/src/test/start/pom.xml
@@ -2,6 +2,7 @@
 <!--
 
     Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2022 Contributors to Eclipse Foundation. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,7 +23,7 @@
   <parent>
     <groupId>org.glassfish.embedded.tester</groupId>
     <artifactId>tester-parent</artifactId>
-    <version>5.1-SNAPSHOT</version>
+    <version>7.0-SNAPSHOT</version>
   </parent>
   <artifactId>startstop-tester</artifactId>
   <packaging>pom</packaging>


### PR DESCRIPTION
This plugin does not have to share the version with GF, but to reduce possible confusion - I propose to do it for now.

Related:
- eclipse-ee4j/glassfish-maven-embedded-plugin#39