### PR TITLE
Fix warning/error from maven-plugin-plugin:descriptor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,11 +157,13 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <version>${target.maven.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-compat</artifactId>
             <version>${target.maven.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish.main.common</groupId>


### PR DESCRIPTION
```
Error:

Some dependencies of Maven Plugins are expected to be in provided scope.
Please make sure that dependencies listed below declared in POM
have set '<scope>provided</scope>' as well.

The following dependencies are in wrong scope:
 * org.apache.maven:maven-plugin-api:jar:3.6.3:compile
 * org.apache.maven:maven-model:jar:3.6.3:compile
 * org.apache.maven:maven-artifact:jar:3.6.3:compile
 * org.apache.maven:maven-compat:jar:3.6.3:compile
 * org.apache.maven:maven-model-builder:jar:3.6.3:compile
 * org.apache.maven:maven-builder-support:jar:3.6.3:compile
 * org.apache.maven:maven-settings:jar:3.6.3:compile
 * org.apache.maven:maven-settings-builder:jar:3.6.3:compile
 * org.apache.maven:maven-core:jar:3.6.3:compile
 * org.apache.maven:maven-resolver-provider:jar:3.6.3:compile
 * org.apache.maven:maven-repository-metadata:jar:3.6.3:compile
```