### PR TITLE
Bump simple-glassfish-api from 5.0 to 7.0.0-M4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
         <dependency>
             <groupId>org.glassfish.main.common</groupId>
             <artifactId>simple-glassfish-api</artifactId>
-            <version>5.0</version>
+            <version>7.0.0-M4</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
M7 is not yet in central, [M4](https://repo.maven.apache.org/maven2/org/glassfish/main/common/simple-glassfish-api/7.0.0-M4/) is. So it's not clear for me which one to pick - using M7 here as workflow activates staging.